### PR TITLE
Upgrading the base environment to deian:buster and fix php dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,30 @@
 # Yeah I know... not the perfect one
 # but you know, never change a running
 # system...
-FROM debian:jessie
+FROM debian:buster
 
 MAINTAINER t0kx <t0kx@protonmail.ch>
+MAINTAINER catop <defenderink826@gmail.com>
+
+# for old version php installation(5.6)
+RUN apt-get update && \
+    apt-get install -y wget && \
+    wget -O /etc/apt/trusted.gpg.d/php.gpg https://mirror.xtom.com.hk/sury/php/apt.gpg && \
+    apt-get install -y apt-transport-https && \
+    echo "deb https://packages.sury.org/php/ buster main" > /etc/apt/sources.list.d/php.list
 
 # install debian stuff
 RUN apt-get update && \
     apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    wget apache2 php5 php5-sqlite sqlite3 git golang sendmail-bin \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    wget apache2 php5.6 php5.6-sqlite3 sqlite3 git golang sendmail-bin
+
+# install php extensions
+RUN apt-get install -y php5.6-mbstring php5.6-zip && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # "configure" smtpd and imapd
-RUN echo "127.0.1.1 myhostname myhostname" >> /etc/hosts && \
-    GOPATH=/tmp/ go get github.com/jordwest/imap-server/demo && \
+RUN GOPATH=/tmp/ go get github.com/jordwest/imap-server/demo && \
     GOPATH=/tmp/ go build github.com/jordwest/imap-server/demo && \
     yes Y | sendmailconfig
 


### PR DESCRIPTION
Since deian:jessie has ended its life cycle and cannot use apt-get to download packages, we adjust the base mirror to deian:buster.
At the same time, use a third-party apt source to download php5.6.